### PR TITLE
fix: ensure doctype is present

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,6 +4,7 @@ const FileSystemAssetLoader = require('./fileSystemAssetLoader');
 
 const DEFAULT_DOCTYPE = '<!DOCTYPE html>';
 
+// TODO(ethan): move over to PercyAgent once https://github.com/percy/percy-agent/pull/168 lands
 class PercySeleniumClient {
   constructor({ driver, assetLoaderOpts, ...clientOptions }) {
     this.percyClient = new PercyClient({

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,6 +2,8 @@ const PercyClient = require('percy-client');
 
 const FileSystemAssetLoader = require('./fileSystemAssetLoader');
 
+const DEFAULT_DOCTYPE = '<!DOCTYPE html>';
+
 class PercySeleniumClient {
   constructor({ driver, assetLoaderOpts, ...clientOptions }) {
     this.percyClient = new PercyClient({
@@ -54,7 +56,7 @@ class PercySeleniumClient {
   }
 
   async createSnapshot(options) {
-    const source = await this.driver.getPageSource();
+    const source = await this.domSnapshot();
     const rootResource = this.percyClient.makeResource({
       resourceUrl: '/',
       content: source,
@@ -75,6 +77,37 @@ class PercySeleniumClient {
 
   async finalizeBuild() {
     await this.percyClient.finalizeBuild(this.buildId);
+  }
+
+  async domSnapshot() {
+    const docType = await this.getDoctype();
+    const dom = await this.driver.executeScript(
+      // eslint-disable-next-line
+      () => window.document.documentElement.outerHTML,
+    );
+    return docType + dom;
+  }
+
+  async getDoctype() {
+    const doctype = await this.driver.executeScript(
+      // eslint-disable-next-line
+      () => window.document.doctype,
+    );
+
+    return doctype ? this.doctypeToString(doctype) : DEFAULT_DOCTYPE;
+  }
+
+  doctypeToString(doctype) {
+    const publicDeclaration = doctype.publicId
+      ? ` PUBLIC "${doctype.publicId}" `
+      : '';
+    const systemDeclaration = doctype.systemId
+      ? ` SYSTEM "${doctype.systemId}" `
+      : '';
+
+    return `<!DOCTYPE ${
+      doctype.name
+    } ${publicDeclaration} ${systemDeclaration}>`;
   }
 }
 


### PR DESCRIPTION
In CircleCI, webdriver was not sending us the doctype, which made the the HTML that Percy received to be incorrect. This will ensure that there is a doctype present and default to the standard `html` doctype.

This PR is a quick fix until we switch over to PercyAgent (https://github.com/percy/percy-agent). Waiting for https://github.com/percy/percy-agent/pull/168 to land